### PR TITLE
Add header GIF to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Header Image](https://github.com/nate-dryer/nate-dryer/blob/main/GIF_2.gif)
+
 <h1 align="center">Hi there 👋, I'm Nate Dryer</h1>
 <h2 align="center">AI/ML Builder | Product Manager | UX & Data Analysis </h2>
 


### PR DESCRIPTION
Adds a header image to the README.md file using markdown syntax.

- Embeds the GIF 'GIF_2.gif' as a header image at the top of the README.md file.
- Utilizes the raw URL `https://github.com/nate-dryer/nate-dryer/blob/main/GIF_2.gif` for the GIF link.
- Sets the alt text for the image to "Header Image".


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nate-dryer/nate-dryer?shareId=282ead0b-3f50-4547-878f-a198b386432a).