### PR TITLE
Add static badges information file

### DIFF
--- a/BADGES.md
+++ b/BADGES.md
@@ -1,0 +1,16 @@
+# Static Badges
+
+## LinkedIn Badge
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-natedryer-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/natedryer)
+
+## GitHub Badge
+[![GitHub](https://img.shields.io/badge/GitHub-nate--dryer-181717?style=for-the-badge&logo=github&logoColor=white)](https://www.github.com/nate-dryer)
+
+## Updated Resume Badge
+[![Resume](https://img.shields.io/badge/Resume-View-brightgreen?style=for-the-badge&logo=read-the-docs&logoColor=white)](https://registry.jsonresume.org/natedryer?theme=macchiato)
+
+## Personal Site Badge
+[![Website](https://img.shields.io/badge/Website-natedryer.com-FF5722?style=for-the-badge&logo=google-chrome&logoColor=white)](https://www.natedryer.com)
+
+## Gmail Badge
+[![Gmail](https://img.shields.io/badge/Gmail-Contact_Me-D14836?style=for-the-badge&logo=gmail&logoColor=white)](mailto:nate@natedryer.com)


### PR DESCRIPTION
Adds a new file `BADGES.md` to the repository containing static badges information as specified in the task.
- Introduces LinkedIn, GitHub, Updated Resume, Personal Site, and Gmail badges with markdown links and images.
- Organizes badges under separate headings for clarity and easy access.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nate-dryer/nate-dryer?shareId=c78031eb-5595-49de-89af-70a514f60d41).